### PR TITLE
Change to Centos7 Base Image

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ Then you can enter the environment.
 distrobox enter hps-env
 ```
 Now you are in a terminal inside the box with all the HPS dependencies installed.
-It is Ubuntu 20.04 and is connected to your screen for graphical apps.
+It is CentOS7 (v2+, Ubuntu 20.04 for versions less than 2) and is connected to your 
+screen for graphical apps.
 You have password-less `sudo` access to install anything else into the box you may
 want. Changes to the box will not be persisted if the box is ever "stopped" but
 generally the only time boxes are stopped are when a computer is rebooted.

--- a/context/Dockerfile
+++ b/context/Dockerfile
@@ -33,9 +33,6 @@ RUN yum install -y \
       fftw-devel \
       findutils \
       ftgl-devel \
-      gcc \
-      gcc-c++ \
-      gcc-gfortran \
       git \
       glew-devel \
       gnupg2 \
@@ -73,6 +70,14 @@ RUN yum install -y \
       util-linux \
       wget \
       vte-profile
+
+# gcc-8 can be installed via the developer toolset
+RUN yum install -y centos-release-scl
+
+RUN yum install -y \
+      devtoolset-8-gcc \
+      devtoolset-8-gcc-c++ \
+      devtoolset-8-gcc-gfortran
 
 RUN python3 -m pip install --no-cache-dir cmake==3.22
 

--- a/context/Dockerfile
+++ b/context/Dockerfile
@@ -22,6 +22,7 @@ ENV __prefix /usr/local
 RUN sed -i '/tsflags=nodocs/d' /etc/yum.conf
 
 RUN yum install -y \
+      avahi-compat-libdns_sd-devel \
       bash \
       binutils \
       zsh \
@@ -29,14 +30,39 @@ RUN yum install -y \
 			curl \
       dialog \
 			diffutils \
+      fftw-devel \
 			findutils \
+      ftgl-devel \
+      gcc \
+      gcc-c++ \
+      gcc-gfortran \
+      git \
+      glew-devel \
 			gnupg2 \
+      graphviz-devel \
+      gsl-devel \
 			less \
+      libuuid-devel \
+      libX11-devel \
+      libXext-devel \
+      libXft-devel \
+      libxml2-devel \
+      libXpm-devel \
 			lsof \
+      make \
+      mesa-libGL-devel \
+      mesa-libGLU-devel \
 			ncurses \
+      openldap-devel \
+      openssl-devel \
 			passwd \
+      pcre-devel \
 			pinentry \
 			procps \
+      python3-numpy \
+      qt5-qtwebengine-devel \
+      redhat-lsb-core \
+      readline-devel \
 			shadow-utils \
 			sudo \
 			time \
@@ -44,58 +70,7 @@ RUN yum install -y \
 			wget \
 			vte-profile
 
-# First install any required dependencies from ubuntu repos
-# Ongoing documentation for this list is in docs/ubuntu-packages.md
-RUN apt-get update &&\
-    DEBIAN_FRONTEND=noninteractive \
-    apt-get install -y \
-        binutils \
-        ca-certificates \
-        cmake \
-        default-jre \
-        fonts-freefont-ttf \
-        g++ \
-        gcc \
-        gfortran \
-        git \
-        libafterimage-dev \
-        libfftw3-dev \
-        libfreetype6-dev \
-        libftgl-dev \
-        libgif-dev \
-        libgl1-mesa-dev \
-        libgl2ps-dev \
-        libglew-dev \
-        libglu-dev \
-        libgsl-dev \
-        libjpeg-dev \
-        liblz4-dev \
-        liblzma-dev \
-        libnss-myhostname \
-        libpcre++-dev \
-        libpng-dev \
-        libssl-dev \
-        libx11-dev \
-        libxext-dev \  
-        libxft-dev \
-        libxml2-dev \
-        libxmu-dev \
-        libxpm-dev \
-        libz-dev \
-        libzstd-dev \
-        locales \
-        make \
-        python3-dev \
-        python3-pip \
-        python3-numpy \
-        python3-tk \
-        python-is-python3 \
-        srm-ifce-dev \
-    && rm -rf /var/lib/apt/lists/* &&\
-    apt-get autoremove --purge &&\
-    apt-get clean all &&\
-    python3 -m pip install --no-cache-dir \
-        cmake==3.25
+RUN python3 -m pip install --no-cache-dir cmake==3.22
 
 ###############################################################################
 # java and its build tool maeven

--- a/context/Dockerfile
+++ b/context/Dockerfile
@@ -228,7 +228,6 @@ RUN mkdir src &&\
         -DGEANT4_INSTALL_DATA=ON \
         -DGEANT4_USE_GDML=ON \
         -DGEANT4_INSTALL_EXAMPLES=OFF \
-        -DGEANT4_USE_OPENGL_X11=ON \
         -DCMAKE_INSTALL_PREFIX=${__prefix} \
         -B src/build \
         -S src \

--- a/context/Dockerfile
+++ b/context/Dockerfile
@@ -1,6 +1,9 @@
 
-FROM ubuntu:20.04
-LABEL ubuntu.version="20.04"
+# this image is deprecated and is not being maintained,
+#   we may seem builds fail to retrieve this image if it
+#   drops from DockerHub
+FROM centos:7
+LABEL centos.version="7"
 MAINTAINER Tom Eichlersmith <eichl008@umn.edu>
 
 ###############################################################################
@@ -13,27 +16,48 @@ ENV __wget wget -q -O -
 ENV __untar tar -xz --strip-components=1 --directory 
 ENV __prefix /usr/local
 
+# In yum family official images, yum is configured to ignore locale and docs
+# This however, results in a rather poor out-of-the-box experience
+# So, let's enable them.
+RUN sed -i '/tsflags=nodocs/d' /etc/yum.conf
+
+RUN yum install -y \
+      bash \
+      binutils \
+      zsh \
+			bc \
+			curl \
+      dialog \
+			diffutils \
+			findutils \
+			gnupg2 \
+			less \
+			lsof \
+			ncurses \
+			passwd \
+			pinentry \
+			procps \
+			shadow-utils \
+			sudo \
+			time \
+			util-linux \
+			wget \
+			vte-profile
+
 # First install any required dependencies from ubuntu repos
 # Ongoing documentation for this list is in docs/ubuntu-packages.md
 RUN apt-get update &&\
     DEBIAN_FRONTEND=noninteractive \
     apt-get install -y \
-        apt-utils \
-        bc \
         binutils \
         ca-certificates \
-        curl \
-        dialog \
-        diffutils \
-        findutils \
+        cmake \
         default-jre \
         fonts-freefont-ttf \
         g++ \
         gcc \
         gfortran \
-        gnupg2 \
         git \
-        less \
         libafterimage-dev \
         libfftw3-dev \
         libfreetype6-dev \
@@ -59,23 +83,14 @@ RUN apt-get update &&\
         libxpm-dev \
         libz-dev \
         libzstd-dev \
-        lsof \
         locales \
         make \
-        ncurses-base \
-        passwd \
-        pinentry-curses \
-        procps \
         python3-dev \
         python3-pip \
         python3-numpy \
         python3-tk \
         python-is-python3 \
         srm-ifce-dev \
-        sudo \
-        time \
-        util-linux \
-        wget \
     && rm -rf /var/lib/apt/lists/* &&\
     apt-get autoremove --purge &&\
     apt-get clean all &&\

--- a/context/Dockerfile
+++ b/context/Dockerfile
@@ -26,49 +26,53 @@ RUN yum install -y \
       bash \
       binutils \
       zsh \
-			bc \
-			curl \
+      bc \
+      curl \
       dialog \
-			diffutils \
+      diffutils \
       fftw-devel \
-			findutils \
+      findutils \
       ftgl-devel \
       gcc \
       gcc-c++ \
       gcc-gfortran \
       git \
       glew-devel \
-			gnupg2 \
+      gnupg2 \
       graphviz-devel \
       gsl-devel \
-			less \
+      less \
       libuuid-devel \
       libX11-devel \
       libXext-devel \
       libXft-devel \
       libxml2-devel \
       libXpm-devel \
-			lsof \
+      lsof \
       make \
       mesa-libGL-devel \
       mesa-libGLU-devel \
-			ncurses \
+      ncurses \
       openldap-devel \
       openssl-devel \
-			passwd \
+      passwd \
       pcre-devel \
-			pinentry \
-			procps \
+      pinentry \
+      procps \
+      python3 \
+      python3-devel \
       python3-numpy \
+      python3-pip \
+      python3-tkinter \
       qt5-qtwebengine-devel \
       redhat-lsb-core \
       readline-devel \
-			shadow-utils \
-			sudo \
-			time \
-			util-linux \
-			wget \
-			vte-profile
+      shadow-utils \
+      sudo \
+      time \
+      util-linux \
+      wget \
+      vte-profile
 
 RUN python3 -m pip install --no-cache-dir cmake==3.22
 

--- a/context/Dockerfile
+++ b/context/Dockerfile
@@ -312,12 +312,17 @@ RUN ldconfig -v
 
 ###############################################################################
 # Extra Python packages
+#   Need to update pip first
 ###############################################################################
 RUN python3 -m pip install --upgrade --no-cache-dir \
+        pip &&\
+    python3 -m pip install --upgrade --no-cache-dir \
         Cython \
         uproot \
         numpy \
         matplotlib \
         mplhep \
         pandas \
+        awkward \
+        "hist[plot]" \
         "typer[all]"

--- a/context/Dockerfile
+++ b/context/Dockerfile
@@ -81,6 +81,19 @@ RUN yum install -y \
 
 RUN python3 -m pip install --no-cache-dir cmake==3.22
 
+# copy in the env PATH variables defined in the devtoolset-8 enable script
+#    these are the first time many of these are defined so we only include
+#    the suffix of the original variable for PATH
+ENV PATH=/opt/rh/devtoolset-8/root/usr/bin:${PATH}
+ENV MANPATH=/opt/rh/devtoolset-8/root/usr/share/man
+ENV INFOPATH=/opt/rh/devltoolset-8/root/usr/share/info
+ENV PCP_DIR=/opt/rh/devtoolset-8/root
+ENV PERL5LIB=/opt/rh/devtoolset-8/root/usr/lib64/perl5/vendor_perl:/opt/rh/devtoolset-8/root/usr/lib/perl5:/opt/rh/devtoolset-8/root/usr/share/perl5/vendor_perl
+ENV LD_LIBRARY_PATH=/opt/rh/devltoolset-8/root/usr/lib64:/opt/rh/devltoolset-8/root/usr/lib
+ENV PYTHONPATH=/opt/rh/devtoolset-8/root/usr/lib64/python2.7/site-packages:/opt/rh/devtoolset-8/root/usr/lib/python2.7/site-packages
+ENV PKG_CONFIG_PATH=/opt/rh/devtoolset-8/root/usr/lib64/pkgconfig
+
+
 ###############################################################################
 # java and its build tool maeven
 #   both are just unpacking precompiled binaries for Linux into /usr/local
@@ -92,9 +105,11 @@ ENV JAVA_HOME=/usr/local/java
 ENV MVN_HOME=/usr/local/mvn
 ENV PATH=${JAVA_HOME}/bin:${MVN_HOME}/bin:${PATH}
 RUN mkdir ${JAVA_HOME} ${MVN_HOME} &&\
-    ${__wget} https://download.java.net/java/GA/jdk15.0.1/51f4f36ad4ef43e39d0dfdbaf6549e32/9/GPL/openjdk-15.0.1_linux-x64_bin.tar.gz |\
+    ${__wget} --no-check-certificate \
+      https://download.java.net/java/GA/jdk15.0.1/51f4f36ad4ef43e39d0dfdbaf6549e32/9/GPL/openjdk-15.0.1_linux-x64_bin.tar.gz |\
       ${__untar} ${JAVA_HOME} &&\
-    ${__wget} https://dlcdn.apache.org/maven/maven-3/3.9.0/binaries/apache-maven-3.9.0-bin.tar.gz |\
+    ${__wget} --no-check-certificate \
+      https://dlcdn.apache.org/maven/maven-3/3.9.0/binaries/apache-maven-3.9.0-bin.tar.gz |\
       ${__untar} ${MVN_HOME}
 
 ###############################################################################


### PR DESCRIPTION
At the request of @cbravo135 I have ported the environment container to be based on CentOS7.

I am not confident in this but it is closer to the nodes that are commonly used for batch computing e.g. at SLAC. Hopefully, updating to a later CentOS or RHEL-like distribution will be easier now that it is in this form.