### PR TITLE
update GBL version to v3.1

### DIFF
--- a/context/Dockerfile
+++ b/context/Dockerfile
@@ -193,7 +193,7 @@ RUN git clone --depth 1 --branch V03-01-00 \
       https://gitlab.desy.de/claus.kleinwort/general-broken-lines.git &&\
     cmake \
       -B general-broken-lines/build \
-      -S general-broken-lines \
+      -S general-broken-lines/cpp \
       -DCMAKE_INSTALL_PREFIX=/usr/local &&\
     cmake \
       --build general-broken-lines/build \

--- a/context/Dockerfile
+++ b/context/Dockerfile
@@ -103,7 +103,7 @@ ENV PKG_CONFIG_PATH=/opt/rh/devtoolset-8/root/usr/lib64/pkgconfig
 #   and then setting appropriate environment variables
 ###############################################################################
 LABEL java.version="15.1.0"
-LABEL mvn.version="3.9.0"
+LABEL mvn.version="3.9.1"
 ENV JAVA_HOME=/usr/local/java
 ENV MVN_HOME=/usr/local/mvn
 ENV PATH=${JAVA_HOME}/bin:${MVN_HOME}/bin:${PATH}
@@ -112,7 +112,7 @@ RUN mkdir ${JAVA_HOME} ${MVN_HOME} &&\
       https://download.java.net/java/GA/jdk15.0.1/51f4f36ad4ef43e39d0dfdbaf6549e32/9/GPL/openjdk-15.0.1_linux-x64_bin.tar.gz |\
       ${__untar} ${JAVA_HOME} &&\
     ${__wget} --no-check-certificate \
-      https://dlcdn.apache.org/maven/maven-3/3.9.0/binaries/apache-maven-3.9.0-bin.tar.gz |\
+      https://dlcdn.apache.org/maven/maven-3/3.9.1/binaries/apache-maven-3.9.1-bin.tar.gz |\
       ${__untar} ${MVN_HOME}
 
 ###############################################################################

--- a/context/Dockerfile
+++ b/context/Dockerfile
@@ -188,21 +188,17 @@ RUN mkdir src &&\
 ###############################################################################
 # GeneralBrokenLines
 ###############################################################################
-LABEL gbl.version=2.2.0
-RUN mkdir src &&\
-    ${__wget} https://github.com/pbutti/GeneralBrokenLines/tarball/master |\
-      ${__untar} src &&\
-    echo "# removed on purpose" > src/cpp/cmake/ilcsoft_default_install_prefix.cmake &&\
+LABEL gbl.version="V03-01-00"
+RUN git clone --depth 1 --branch V03-01-00 \
+      https://gitlab.desy.de/claus.kleinwort/general-broken-lines.git &&\
     cmake \
-      -DCMAKE_INSTALL_PREFIX=${__prefix} \
-      -B src/cpp/build \
-      -S src/cpp \
-    &&\
+      -B general-broken-lines/build \
+      -S general-broken-lines \
+      -DCMAKE_INSTALL_PREFIX=/usr/local &&\
     cmake \
-      --build src/cpp/build \
-      --target install \
-    &&\
-    rm -rf src
+      --build general-broken-lines/build \
+      --target install &&\
+    rm -rf general-broken-lines
 
 ################################################################################
 # Xerces-C 


### PR DESCRIPTION
With a new release including the GBL-JNA wrapper developments, we can now build the version into our environment image.

This means branches that do not include the updated GBL-JNA interface in hps-java will not function with the GBL installed within the container. It doesn't take long to build so it is easy enough to just build it yourself and pass the `-Djna.library.path=/full/path/to/gbl` command line argument to `java`.

https://github.com/JeffersonLab/hps-java/pull/958