### PR TITLE
add python2 to support MadGraph4

### DIFF
--- a/context/Dockerfile
+++ b/context/Dockerfile
@@ -55,6 +55,7 @@ RUN apt-get update &&\
         passwd \
         pinentry-curses \
         procps \
+        python2 \
         python3-dev \
         python3-pip \
         python3-numpy \


### PR DESCRIPTION
MG4 requires python2 to run its code-writing scripts :angry: so I need to install it